### PR TITLE
keep coordinates along unchanged dimensions

### DIFF
--- a/xarray_healpy/regridder.py
+++ b/xarray_healpy/regridder.py
@@ -85,8 +85,16 @@ class HealpyRegridder:
                 dims=src_dims,
             )
 
+        unchanged_coords = {
+            k: v
+            for k, v in ds.coords.items()
+            if not set(self.weights.attrs["sum_dims"]).intersection(v.dims)
+        }
+
+        # TODO: copy over existing indexes on unchanged coords
         return (
             ds.map(_apply_weights, weights=self.weights.chunk())
             .assign_attrs(self.output_grid.attrs)
             .assign_coords(cell_ids=self.weights["cell_ids"])
+            .assign_coords({"cell_ids": self.weights["cell_ids"]} | unchanged_coords)
         )


### PR DESCRIPTION
At the moment, the regridder will drop coordinates that are not affected by the regridding. We do want to keep those, though.

The current implementation simply copies those coordinates over, but drops the associated indexes. By using `xr.Coordinates` we could keep those, as well, but would require a bit more investigation. So this will be done in another PR.