### PR TITLE
actually transform to unrotated

### DIFF
--- a/xarray_healpy/conversions.py
+++ b/xarray_healpy/conversions.py
@@ -5,8 +5,8 @@ import xarray as xr
 
 
 def geographic_to_cartesian(lon, lat, rot, dim=None):
-    lon_ = lon + rot["lon"]
-    lat_ = lat + rot["lat"]
+    lon_ = lon - rot["lon"]
+    lat_ = lat - rot["lat"]
 
     if dim is None:
         dims = list(lon.dims)


### PR DESCRIPTION
The rotation in `geographic_to_cartesian` was wrong, it was converting to *global* instead of to *rotated* (i.e. `rot` was applied with the wrong sign).